### PR TITLE
Add link to hash on twitter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Welcome to the #WebOnPi project!
+# Welcome to the WebOnPi project!
 
-This repo contains the default XAML application for the #WebOnPi project. The majority of the code was borrowed from [the Windows IoT Core samples](https://github.com/ms-iot/samples/tree/develop/IoTCoreDefaultApp).
+This repo contains the default XAML application for the [#WebOnPi](https://twitter.com/search?f=tweets&vertical=default&q=%23WebOnPi) project. The majority of the code was borrowed from [the Windows IoT Core samples](https://github.com/ms-iot/samples/tree/develop/IoTCoreDefaultApp).
 
 ##Other
 


### PR DESCRIPTION
This PR adds a link to the twitter hash mentioned in the readme.
